### PR TITLE
Fixed puppet init for php

### DIFF
--- a/puppet/modules/php/manifests/init.pp
+++ b/puppet/modules/php/manifests/init.pp
@@ -1,10 +1,9 @@
 class php {
 
-	package { ['php5-fpm',
-						 'php5-cli,
-             'php5-mysql']:
+	package { ['php5-fpm','php5-cli','php5-mysql']:
 	  ensure => present,
 	  require => Exec['apt-get update'],
+	  notify  => Service["php5-fpm"],
 	}
 
 	service { 'php5-fpm':


### PR DESCRIPTION
Syntax error (missing ')
and added notify (otherwise mysql driver would only be found after second start of the vagrant machine)
